### PR TITLE
Avoid Method Errors When Upgrading New Gems

### DIFF
--- a/lib/workarea/upgrade/diff.rb
+++ b/lib/workarea/upgrade/diff.rb
@@ -54,17 +54,14 @@ module Workarea
       end
 
       def gems
-        core = %w(workarea-core workarea-storefront workarea-admin)
-          .inject({}) do |memo, gem|
-            memo[gem] = @core_to_version
-            memo
-          end
-
-        core.merge(plugins)
+        %w(workarea-core workarea-storefront workarea-admin)
+          .each_with_object({}) { |gem, memo| memo[gem] = @core_to_version }
+          .merge(plugins)
+          .select { |gem, _version| find_from_path!(gem).present? }
       end
 
       def find_from_path!(gem)
-        Bundler.load.specs.find { |s| s.name == "#{gem}" }.full_gem_path
+        Bundler.load.specs.find { |s| s.name == "#{gem}" }&.full_gem_path
       end
 
       def find_to_path!(gem, version)


### PR DESCRIPTION
When a new gem has been included in an upgrading gem's dependencies, an
error can be thrown when viewing the diff or report if the gem is not
already included in the app's Gemfile prior to running the upgrade
tools. Ensure that `Workarea::Upgrade::Diff#find_from_path!` returns
`nil` when this occurs, and the diff generator skips over gems that it
cannot produce a `Workarea::Upgrade::GemDiff` for.