### PR TITLE
Loosen Bundler Version Constraint

### DIFF
--- a/workarea-upgrade.gemspec
+++ b/workarea-upgrade.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'bundler', '~> 2.0.0'
+  s.add_dependency 'bundler', '~> 2'
   s.add_dependency 'diffy', '~> 3.1.0'
 
-  s.add_development_dependency 'workarea', '~> 3.x'
+  s.add_development_dependency 'workarea', '~> 3'
 end


### PR DESCRIPTION
Allow any version of Bundler 2 to be used with `Workarea::Upgrade` so
that users can install the right version on their apps.