### PR TITLE
Fix incomplete rails envrionment error

### DIFF
--- a/lib/workarea/upgrade.rb
+++ b/lib/workarea/upgrade.rb
@@ -1,4 +1,5 @@
 require 'active_support/all'
+require 'action_view/railtie'
 
 require 'workarea'
 require 'workarea/storefront'


### PR DESCRIPTION
Ran in to an issue across multiple machines where running this would throw an error about an undefined constant from ActionView. Found reports of the same error in other rails-adjacent projects where part of the base rails libraries weren't getting loaded or were loading in the wrong order. Explicitly pulling in the ActionView railtie here loads all the needed stuff ahead of time.